### PR TITLE
Update dependencies

### DIFF
--- a/Centre-Registry-config/setup.py
+++ b/Centre-Registry-config/setup.py
@@ -14,7 +14,7 @@ setup(
     name='centre_registry_config',
     use_scm_version={
         "root": "..",
-        "fallback_version": "2.3.0.dev0"
+        "fallback_version": "2.3.1.dev0"
     },
     setup_requires=['setuptools_scm'],
     packages=['centre_registry_project'],

--- a/centre-registry-app/setup.py
+++ b/centre-registry-app/setup.py
@@ -15,7 +15,7 @@ setup(
     name='centre_registry_app',
     use_scm_version={
         "root": "..",
-        "fallback_version": "2.3.0.dev0"
+        "fallback_version": "2.3.1.dev0"
     },
     setup_requires=['setuptools_scm'],
     packages=['centre_registry'],

--- a/centre-registry-app/setup.py
+++ b/centre-registry-app/setup.py
@@ -8,7 +8,7 @@ from os.path import normpath
 from setuptools import setup
 
 INSTALL_REQUIRES = ['Django==2.2.16', 'django-debug-toolbar==2.1']
-TEST_REQUIRES = ['lxml==4.5.2', 'selenium==3.141.0', 'jsonschema==3.1.1', 'django-test-migrations==0.2.0']
+TEST_REQUIRES = ['lxml==4.5.2', 'selenium==3.141.0', 'jsonschema==3.2.0', 'django-test-migrations==0.2.0']
 
 chdir(normpath(join(abspath(__file__), pardir)))
 setup(

--- a/centre-registry-app/setup.py
+++ b/centre-registry-app/setup.py
@@ -7,7 +7,7 @@ from os.path import normpath
 
 from setuptools import setup
 
-INSTALL_REQUIRES = ['Django==2.2.14', 'django-debug-toolbar==2.1']
+INSTALL_REQUIRES = ['Django==2.2.16', 'django-debug-toolbar==2.1']
 TEST_REQUIRES = ['lxml==4.5.0', 'selenium==3.141.0', 'jsonschema==3.1.1', 'django-test-migrations==0.2.0']
 
 chdir(normpath(join(abspath(__file__), pardir)))

--- a/centre-registry-app/setup.py
+++ b/centre-registry-app/setup.py
@@ -8,7 +8,7 @@ from os.path import normpath
 from setuptools import setup
 
 INSTALL_REQUIRES = ['Django==2.2.16', 'django-debug-toolbar==2.1']
-TEST_REQUIRES = ['lxml==4.5.2', 'selenium==3.141.0', 'jsonschema==3.2.0', 'django-test-migrations==0.2.0']
+TEST_REQUIRES = ['lxml==4.5.2', 'selenium==3.141.0', 'jsonschema==3.2.0', 'django-test-migrations==1.0.0']
 
 chdir(normpath(join(abspath(__file__), pardir)))
 setup(

--- a/centre-registry-app/setup.py
+++ b/centre-registry-app/setup.py
@@ -8,7 +8,7 @@ from os.path import normpath
 from setuptools import setup
 
 INSTALL_REQUIRES = ['Django==2.2.16', 'django-debug-toolbar==2.1']
-TEST_REQUIRES = ['lxml==4.5.0', 'selenium==3.141.0', 'jsonschema==3.1.1', 'django-test-migrations==0.2.0']
+TEST_REQUIRES = ['lxml==4.5.2', 'selenium==3.141.0', 'jsonschema==3.1.1', 'django-test-migrations==0.2.0']
 
 chdir(normpath(join(abspath(__file__), pardir)))
 setup(


### PR DESCRIPTION
* Upgrade to [Django 2.2.16](https://docs.djangoproject.com/en/3.0/releases/2.2.16/#django-2-2-16-release-notes)
Fixes Django vulnerabilities:
  * http://nvd.nist.gov/nvd.cfm?cvename=CVE-2020-24583
  * http://nvd.nist.gov/nvd.cfm?cvename=CVE-2020-24584
* Update lxml to 4.5.2
* Update jsonschema to 3.2.0
* Update django-test-migrations to 1.0.0
* Bump build fallback version to 2.3.1.dev0